### PR TITLE
Add UI language setting

### DIFF
--- a/src/gui/app/app-main.js
+++ b/src/gui/app/app-main.js
@@ -76,7 +76,7 @@
                     prefix: "lang/locale-",
                     suffix: ".json"
                 })
-                .preferredLanguage("en");
+                .preferredLanguage(firebotAppDetails.locale);
         }
     ]);
 
@@ -137,9 +137,14 @@
         videoService,
         replaceVariableService,
         variableMacroService,
-        uiExtensionsService
+        uiExtensionsService,
+        $translate
     ) {
         // 'chatMessagesService' and 'videoService' are included so they're instantiated on app start
+
+        const language = settingsService.getSetting("UiLanguage") || firebotAppDetails.locale;
+        $translate.use(language);
+        moment.locale(language);
 
         connectionService.loadProfiles();
 
@@ -421,6 +426,10 @@
         // Apply Theme
         $scope.appTheme = function() {
             return settingsService.getSetting("Theme");
+        };
+
+        $scope.appLanguage = function() {
+            return settingsService.getSetting("UiLanguage") || 'en';
         };
 
         $rootScope.showSpinner = false;

--- a/src/gui/app/directives/settings/categories/general-settings.js
+++ b/src/gui/app/directives/settings/categories/general-settings.js
@@ -14,6 +14,20 @@
                             ng-init="selectedTheme = settings.getSetting('Theme')"
                             selected="selectedTheme"
                             on-update="settings.saveSetting('Theme', option)"
+                        right-justify="true"
+                    />
+                    </firebot-setting>
+
+                    <firebot-setting
+                        name="Language"
+                        description="Change the language used for Firebot's interface. Requires restart."
+                    >
+                        <firebot-select
+                            aria-label="UI Language"
+                            options="availableLanguages"
+                            ng-init="selectedLang = settings.getSetting('UiLanguage')"
+                            selected="selectedLang"
+                            on-update="settings.saveSetting('UiLanguage', option)"
                             right-justify="true"
                         />
                     </firebot-setting>
@@ -197,6 +211,8 @@
         controller: function ($rootScope, $scope, settingsService, $q) {
             $scope.openLink = $rootScope.openLinkExternally;
             $scope.settings = settingsService;
+
+            $scope.availableLanguages = { en: 'English', ja: '日本語' };
 
             $scope.audioOutputDevices = [
                 {

--- a/src/gui/app/index.html
+++ b/src/gui/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-controller="MainController">
+<html ng-controller="MainController" lang="{{appLanguage()}}">
   <head>
     <title ng-bind="appTitle">Firebot</title>
     <link rel="icon" href="../../favicon.ico" />

--- a/src/gui/app/lang/locale-ja.json
+++ b/src/gui/app/lang/locale-ja.json
@@ -1,0 +1,6 @@
+{
+  "MAIN": {
+    "MANAGE_LOGINS": "ログイン管理",
+    "LOADING": "読み込み中..."
+  }
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -90,6 +90,7 @@ export type FirebotSettingsTypes = {
     WebServerPort: number;
     WhileLoopEnabled: boolean;
     WysiwygBackground: "black" | "white";
+    UiLanguage: string;
 }
 
 export const FirebotGlobalSettings: Partial<Record<keyof FirebotSettingsTypes, boolean>> = {
@@ -199,7 +200,8 @@ export const FirebotSettingsDefaults: FirebotSettingsTypes = {
     WebOnlineCheckin: false,
     WebServerPort: 7472,
     WhileLoopEnabled: false,
-    WysiwygBackground: "white"
+    WysiwygBackground: "white",
+    UiLanguage: "en"
 };
 
 /** Anything in `SettingsTypes` not listed here will resolve to "/settings/settingName" (e.g. "/settings/autoFlagBots") */
@@ -217,5 +219,6 @@ export const FirebotSettingsPaths: Partial<Record<keyof FirebotSettingsTypes, st
     ShowActivityFeed: "/settings/activityFeed",
     ShowChatViewerList: "/settings/chatUsersList",
     SoundsEnabled: "/settings/sounds",
-    ViewerListPageSize: "/settings/viewerListDatabase/pageSize"
+    ViewerListPageSize: "/settings/viewerListDatabase/pageSize",
+    UiLanguage: "/settings/uiLanguage"
 };


### PR DESCRIPTION
## Summary
- enable setting UI language in general settings
- load selected UI language at startup
- expose language to index.html and moment.js
- add Japanese translation file

## Testing
- `npm run lint` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418b44f8208322978c8a26f629d531