### PR TITLE
Add developer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ We'd love to hear your idea! You can submit a Feature Request [here](https://git
 This code (everything in the repository) is provided under the GNU General Public License v3.0. This means that you're free to take the code in this repository and modify it in whatever way you like and distribute this code for any purpose. However, if you release it then it must be under this same license, make it open source, and provide documentation of changes made. All versions must have copyright credit pointing back to this source.
 
 **Anything using this code must be under the GNU Public License, and a copyright credit must point back here.**
+
+## Development
+See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for setup instructions.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,10 @@
+# Development
+
+## Getting Started
+
+1. Run `make setup` to install dependencies.
+2. Copy `src/secrets.template.json` to `src/secrets.json` and fill in each field.
+   This file must live alongside `secrets.template.json` inside the `src` folder.
+3. Start Firebot in development mode with `make start`.
+
+`make start` will fail if `src/secrets.json` does not exist or is missing required keys.


### PR DESCRIPTION
## Summary
- add docs/DEVELOPMENT.md with a Getting Started guide
- point the README to the new development docs

## Testing
- `npm run lint` *(fails: grunt: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684196b3d24083229aa5fe92262da738