### PR TITLE
Add secrets generation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup build start clean
+.PHONY: setup build start clean secrets
 
 setup:
 	npm run setup
@@ -11,3 +11,6 @@ start:
 
 clean:
 	npx grunt cleanup
+
+secrets:
+	cp src/secrets.template.json src/secrets.json

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 ## Getting Started
 
 1. Run `make setup` to install dependencies.
-2. Copy `src/secrets.template.json` to `src/secrets.json` and fill in each field.
+2. Generate `src/secrets.json` with `make secrets` and fill in each field.
    This file must live alongside `secrets.template.json` inside the `src` folder.
 3. Start Firebot in development mode with `make start`.
 


### PR DESCRIPTION
## Summary
- add a `secrets` target to copy `src/secrets.template.json`
- mention the new command in Development docs

## Testing
- `make secrets && ls src | grep secrets.json`
- `npm run lint` *(fails: `grunt` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841990a43608322a3eee9ca44683830