### PR TITLE
Add language toggle localization

### DIFF
--- a/src/gui/app/directives/settings/categories/general-settings.js
+++ b/src/gui/app/directives/settings/categories/general-settings.js
@@ -5,11 +5,11 @@
         template: `
                 <div>
                     <firebot-setting
-                        name="Theme"
-                        description="Choose your color theme for Firebot!"
+                        name="{{'SETTINGS.GENERAL.THEME.NAME' | translate }}"
+                        description="{{'SETTINGS.GENERAL.THEME.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
-                            aria-label="App Theme"
+                            aria-label="{{'SETTINGS.GENERAL.THEME.NAME' | translate }}"
                             options="['Light', 'Midnight', 'Obsidian']"
                             ng-init="selectedTheme = settings.getSetting('Theme')"
                             selected="selectedTheme"
@@ -19,11 +19,11 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Language"
-                        description="Change the language used for Firebot's interface."
+                        name="{{'SETTINGS.GENERAL.LANGUAGE.NAME' | translate }}"
+                        description="{{'SETTINGS.GENERAL.LANGUAGE.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
-                            aria-label="UI Language"
+                            aria-label="{{'SETTINGS.GENERAL.LANGUAGE.NAME' | translate }}"
                             options="availableLanguages"
                             ng-init="selectedLang = settings.getSetting('UiLanguage')"
                             selected="selectedLang"

--- a/src/gui/app/lang/locale-en.json
+++ b/src/gui/app/lang/locale-en.json
@@ -78,5 +78,18 @@
   "NEW": "New",
   "CONNECTED": "Connected",
   "DISCONNECTED": "Disconnected",
-  "RUNNING_NOT_CONNECTED": "Ready, but nothing is connected at this time."
+  "RUNNING_NOT_CONNECTED": "Ready, but nothing is connected at this time.",
+  "SETTINGS": {
+    "GENERAL": {
+      "THEME": {
+        "NAME": "Theme",
+        "DESCRIPTION": "Choose your color theme for Firebot!"
+      },
+      "LANGUAGE": {
+        "NAME": "Language",
+        "DESCRIPTION": "Change the language used for Firebot's interface."
+      }
+    }
+  }
 }
+

--- a/src/gui/app/lang/locale-ja.json
+++ b/src/gui/app/lang/locale-ja.json
@@ -78,5 +78,18 @@
   "NEW": "新規",
   "CONNECTED": "接続済み",
   "DISCONNECTED": "切断済み",
-  "RUNNING_NOT_CONNECTED": "準備完了しましたが、現在接続されていません。"
+  "RUNNING_NOT_CONNECTED": "準備完了しましたが、現在接続されていません。",
+  "SETTINGS": {
+    "GENERAL": {
+      "THEME": {
+        "NAME": "テーマ",
+        "DESCRIPTION": "Firebotのカラーテーマを選択します"
+      },
+      "LANGUAGE": {
+        "NAME": "言語",
+        "DESCRIPTION": "Firebotのインターフェースで使用する言語を変更します。"
+      }
+    }
+  }
 }
+


### PR DESCRIPTION
## Summary
- localize theme/language settings
- add Japanese translations for settings toggle

## Testing
- `npm run lint` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419f158df883228b997d3ee561d06a