### PR TITLE
Add more translation hooks

### DIFF
--- a/src/gui/app/lang/locale-en.json
+++ b/src/gui/app/lang/locale-en.json
@@ -90,6 +90,23 @@
         "DESCRIPTION": "Change the language used for Firebot's interface."
       }
     }
+  },
+  "CURRENCY_PAGE": {
+    "ADD_CURRENCY": "Add Currency",
+    "NO_CURRENCY_SAVED": "No currencies saved. You should make one! :)"
+  },
+  "HOTKEYS_PAGE": {
+    "NEW_HOTKEY": "New Hotkey",
+    "NO_HOTKEYS_SAVED": "No hotkeys saved. You should make one! :)"
+  },
+  "QUOTES_PAGE": {
+    "ADD_QUOTE": "Add Quote",
+    "IMPORT_QUOTES": "Import Quotes",
+    "SEARCH_PLACEHOLDER": "Search quotes...",
+    "NO_QUOTES": "No quotes created yet!"
+  },
+  "SETTINGS_PAGE": {
+    "CLOSE": "Close"
   }
 }
 

--- a/src/gui/app/lang/locale-ja.json
+++ b/src/gui/app/lang/locale-ja.json
@@ -90,6 +90,23 @@
         "DESCRIPTION": "Firebotのインターフェースで使用する言語を変更します。"
       }
     }
+  },
+  "CURRENCY_PAGE": {
+    "ADD_CURRENCY": "通貨を追加",
+    "NO_CURRENCY_SAVED": "通貨が保存されていません。作成しましょう！ :)"
+  },
+  "HOTKEYS_PAGE": {
+    "NEW_HOTKEY": "新しいホットキー",
+    "NO_HOTKEYS_SAVED": "ホットキーが保存されていません。作成しましょう！ :)"
+  },
+  "QUOTES_PAGE": {
+    "ADD_QUOTE": "引用を追加",
+    "IMPORT_QUOTES": "引用をインポート",
+    "SEARCH_PLACEHOLDER": "引用を検索...",
+    "NO_QUOTES": "引用はまだ作成されていません！"
+  },
+  "SETTINGS_PAGE": {
+    "CLOSE": "閉じる"
   }
 }
 

--- a/src/gui/app/templates/_currency.html
+++ b/src/gui/app/templates/_currency.html
@@ -1,10 +1,10 @@
 <div class="p-6 mx-0">
-    <button class="btn btn-primary" ng-click="openAddOrEditCurrencyModal()"><i class="fas fa-plus-circle mr-2"></i> Add Currency</button>
+    <button class="btn btn-primary" ng-click="openAddOrEditCurrencyModal()"><i class="fas fa-plus-circle mr-2"></i> {{'CURRENCY_PAGE.ADD_CURRENCY' | translate}}</button>
 </div>
 
 <div class="p-6">
     <div ng-if="currencyService.currencies.length === 0" class="noselect muted pl-5">
-        <span class="hvr-bob"><i class="fas fa-arrow-up"></i></span><span class="ml-3">No currencies saved. You should make one! :) </span>
+        <span class="hvr-bob"><i class="fas fa-arrow-up"></i></span><span class="ml-3">{{'CURRENCY_PAGE.NO_CURRENCY_SAVED' | translate}}</span>
     </div>
 
     <div class="mt-8" style="display:flex;flex-wrap: wrap;">

--- a/src/gui/app/templates/_hotkeys.html
+++ b/src/gui/app/templates/_hotkeys.html
@@ -1,5 +1,5 @@
 <div class="p-6 mx-0">
-    <button class="btn btn-primary" ng-click="openAddOrEditHotkeyModal()"><i class="fas fa-plus-circle" class="mr-2"></i> New Hotkey</button>
+    <button class="btn btn-primary" ng-click="openAddOrEditHotkeyModal()"><i class="fas fa-plus-circle" class="mr-2"></i> {{'HOTKEYS_PAGE.NEW_HOTKEY' | translate}}</button>
 </div>
 
 
@@ -21,6 +21,6 @@
         </div>
     </div>
     <div ng-if="getHotkeys().length < 1" class="noselect muted pl-5">
-        <span class="hvr-bob"><i class="fas fa-arrow-up"></i></span><span class="ml-3">No hotkeys saved. You should make one! :) </span>
+        <span class="hvr-bob"><i class="fas fa-arrow-up"></i></span><span class="ml-3">{{'HOTKEYS_PAGE.NO_HOTKEYS_SAVED' | translate}}</span>
     </div>
 </div>

--- a/src/gui/app/templates/_quotes.html
+++ b/src/gui/app/templates/_quotes.html
@@ -1,8 +1,8 @@
 <div class="p-6 mx-0" style="display: flex;flex-direction: row;justify-content: space-between;">
-    <button ng-click="showAddOrEditQuoteModal()" class="btn btn-primary"><i class="fas fa-plus-circle mr-2"></i> Add Quote</button>
-    <button ng-click="showImportQuotesModal()" class="btn btn-primary ml-2"><i class="fas fa-cloud-download-alt mr-2"></i>Import Quotes</button>
+    <button ng-click="showAddOrEditQuoteModal()" class="btn btn-primary"><i class="fas fa-plus-circle mr-2"></i> {{'QUOTES_PAGE.ADD_QUOTE' | translate}}</button>
+    <button ng-click="showImportQuotesModal()" class="btn btn-primary ml-2"><i class="fas fa-cloud-download-alt mr-2"></i>{{'QUOTES_PAGE.IMPORT_QUOTES' | translate}}</button>
     <div style="display: flex;flex-direction: row;justify-content: space-between;margin-left: auto;">
-        <searchbar placeholder-text="Search quotes..." query="quoteSearch" style="flex-basis: 250px;"></searchbar>
+        <searchbar placeholder-text="{{'QUOTES_PAGE.SEARCH_PLACEHOLDER' | translate}}" query="quoteSearch" style="flex-basis: 250px;"></searchbar>
     </div>
 </div>
 
@@ -16,6 +16,6 @@
         track-by-field="_id"
         starting-sort-field="createdAt"
         sort-initially-reversed="true"
-        no-data-message="No quotes created yet!">
+        no-data-message="{{'QUOTES_PAGE.NO_QUOTES' | translate}}">
     </sortable-table>
 </div>

--- a/src/gui/app/templates/_settings.html
+++ b/src/gui/app/templates/_settings.html
@@ -81,6 +81,6 @@
   </div>
   <div class="modal-footer">
       <button class="btn btn-default pull-left" ng-click="openBackupFolder()">Open Backups Folder</button>
-      <button class="btn btn-primary" ng-click="dismiss()">Close</button>
+      <button class="btn btn-primary" ng-click="dismiss()">{{'SETTINGS_PAGE.CLOSE' | translate}}</button>
   </div>
 </script>


### PR DESCRIPTION
## Summary
- support language toggle for some missing UI text
- add translation strings in Japanese and English

## Testing
- `npm run lint` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a6f357e88322a0367fa97d14af14