### PR TITLE
Enable settings menu translation

### DIFF
--- a/src/gui/app/controllers/settings.controller.js
+++ b/src/gui/app/controllers/settings.controller.js
@@ -8,68 +8,68 @@
 
             $scope.categories = [
                 {
-                    name: "General",
-                    description: "Various settings for appearance, beta notifications, and more.",
+                    name: "SETTINGS_PAGE.CATEGORIES.GENERAL.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.GENERAL.DESCRIPTION",
                     icon: "fa-sliders-v-square",
                     template: "<general-settings />"
                 },
                 {
-                    name: "Setups",
-                    description: "Share your best creations with others. Or import others!",
+                    name: "SETTINGS_PAGE.CATEGORIES.SETUPS.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.SETUPS.DESCRIPTION",
                     icon: "fa-box-full",
                     template: "<setups-settings />"
                 },
                 {
-                    name: "Triggers",
-                    description: "Tweak the behaviors of various triggers (commands, events, etc)",
+                    name: "SETTINGS_PAGE.CATEGORIES.TRIGGERS.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.TRIGGERS.DESCRIPTION",
                     icon: "fa-bolt",
                     template: "<trigger-settings />"
                 },
                 {
-                    name: "Effects",
-                    description: "Various options for effects",
+                    name: "SETTINGS_PAGE.CATEGORIES.EFFECTS.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.EFFECTS.DESCRIPTION",
                     icon: "fa-magic",
                     template: "<effect-settings />"
                 },
                 {
-                    name: "Database",
-                    description: "Options and tools for the viewer database.",
+                    name: "SETTINGS_PAGE.CATEGORIES.DATABASE.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.DATABASE.DESCRIPTION",
                     icon: "fa-database",
                     template: "<database-settings />"
                 },
                 {
-                    name: "Overlay",
-                    description: "Add new fonts, create new instances, and other overlay settings.",
+                    name: "SETTINGS_PAGE.CATEGORIES.OVERLAY.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.OVERLAY.DESCRIPTION",
                     icon: "fa-tv",
                     template: "<overlay-settings />"
                 },
                 {
-                    name: "Integrations",
-                    description: "Link Firebot to a growing list of third party tools and apps.",
+                    name: "SETTINGS_PAGE.CATEGORIES.INTEGRATIONS.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.INTEGRATIONS.DESCRIPTION",
                     icon: "fa-globe",
                     template: "<integration-settings />"
                 },
                 {
-                    name: "TTS",
-                    description: "Settings for the default TTS voice.",
+                    name: "SETTINGS_PAGE.CATEGORIES.TTS.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.TTS.DESCRIPTION",
                     icon: "fa-volume",
                     template: "<tts-settings />"
                 },
                 {
-                    name: "Backups",
-                    description: "Manage backups and backup settings to ensure your data is never lost.",
+                    name: "SETTINGS_PAGE.CATEGORIES.BACKUPS.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.BACKUPS.DESCRIPTION",
                     icon: "fa-file-archive",
                     template: "<backups-settings />"
                 },
                 {
-                    name: "Scripts",
-                    description: "Configure script settings, add start up scripts, and more.",
+                    name: "SETTINGS_PAGE.CATEGORIES.SCRIPTS.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.SCRIPTS.DESCRIPTION",
                     icon: "fa-code",
                     template: "<scripts-settings />"
                 },
                 {
-                    name: "Advanced",
-                    description: "Various advanced settings such as debug mode, while loops, and other tools",
+                    name: "SETTINGS_PAGE.CATEGORIES.ADVANCED.NAME",
+                    description: "SETTINGS_PAGE.CATEGORIES.ADVANCED.DESCRIPTION",
                     icon: "fa-tools",
                     template: "<advanced-settings />"
                 }

--- a/src/gui/app/lang/locale-en.json
+++ b/src/gui/app/lang/locale-en.json
@@ -147,7 +147,53 @@
     "NO_QUOTES": "No quotes created yet!"
   },
   "SETTINGS_PAGE": {
-    "CLOSE": "Close"
+    "CLOSE": "Close",
+    "CATEGORIES": {
+      "GENERAL": {
+        "NAME": "General",
+        "DESCRIPTION": "Various settings for appearance, beta notifications, and more."
+      },
+      "SETUPS": {
+        "NAME": "Setups",
+        "DESCRIPTION": "Share your best creations with others. Or import others!"
+      },
+      "TRIGGERS": {
+        "NAME": "Triggers",
+        "DESCRIPTION": "Tweak the behaviors of various triggers (commands, events, etc)"
+      },
+      "EFFECTS": {
+        "NAME": "Effects",
+        "DESCRIPTION": "Various options for effects"
+      },
+      "DATABASE": {
+        "NAME": "Database",
+        "DESCRIPTION": "Options and tools for the viewer database."
+      },
+      "OVERLAY": {
+        "NAME": "Overlay",
+        "DESCRIPTION": "Add new fonts, create new instances, and other overlay settings."
+      },
+      "INTEGRATIONS": {
+        "NAME": "Integrations",
+        "DESCRIPTION": "Link Firebot to a growing list of third party tools and apps."
+      },
+      "TTS": {
+        "NAME": "TTS",
+        "DESCRIPTION": "Settings for the default TTS voice."
+      },
+      "BACKUPS": {
+        "NAME": "Backups",
+        "DESCRIPTION": "Manage backups and backup settings to ensure your data is never lost."
+      },
+      "SCRIPTS": {
+        "NAME": "Scripts",
+        "DESCRIPTION": "Configure script settings, add start up scripts, and more."
+      },
+      "ADVANCED": {
+        "NAME": "Advanced",
+        "DESCRIPTION": "Various advanced settings such as debug mode, while loops, and other tools"
+      }
+    }
   }
 }
 

--- a/src/gui/app/lang/locale-ja.json
+++ b/src/gui/app/lang/locale-ja.json
@@ -147,7 +147,53 @@
     "NO_QUOTES": "引用はまだ作成されていません！"
   },
   "SETTINGS_PAGE": {
-    "CLOSE": "閉じる"
+    "CLOSE": "閉じる",
+    "CATEGORIES": {
+      "GENERAL": {
+        "NAME": "一般",
+        "DESCRIPTION": "外観やベータ通知などの設定を行います。"
+      },
+      "SETUPS": {
+        "NAME": "セットアップ",
+        "DESCRIPTION": "作成した設定を共有したり、他の人の設定をインポートしたりできます。"
+      },
+      "TRIGGERS": {
+        "NAME": "トリガー",
+        "DESCRIPTION": "コマンドやイベントなど、各種トリガーの動作を調整します。"
+      },
+      "EFFECTS": {
+        "NAME": "エフェクト",
+        "DESCRIPTION": "エフェクトに関するさまざまなオプション。"
+      },
+      "DATABASE": {
+        "NAME": "データベース",
+        "DESCRIPTION": "視聴者データベースのオプションとツール。"
+      },
+      "OVERLAY": {
+        "NAME": "オーバーレイ",
+        "DESCRIPTION": "フォントの追加やインスタンスの作成など、オーバーレイの設定。"
+      },
+      "INTEGRATIONS": {
+        "NAME": "連携",
+        "DESCRIPTION": "Firebotを外部ツールやアプリと連携させます。"
+      },
+      "TTS": {
+        "NAME": "TTS",
+        "DESCRIPTION": "既定のTTS音声に関する設定。"
+      },
+      "BACKUPS": {
+        "NAME": "バックアップ",
+        "DESCRIPTION": "データを失わないよう、バックアップの管理と設定を行います。"
+      },
+      "SCRIPTS": {
+        "NAME": "スクリプト",
+        "DESCRIPTION": "スクリプト設定や起動スクリプトの追加などを行います。"
+      },
+      "ADVANCED": {
+        "NAME": "高度な設定",
+        "DESCRIPTION": "デバッグモードやwhileループなど、上級者向け設定。"
+      }
+    }
   }
 }
 

--- a/src/gui/app/templates/_settings.html
+++ b/src/gui/app/templates/_settings.html
@@ -11,16 +11,16 @@
       </div>
       <div>
         <div style="font-weight: 600;">
-          {{category.name}}
+          {{category.name | translate}}
         </div>
         <div style="opacity: 0.7;">
-          {{category.description}}
+          {{category.description | translate}}
         </div>
       </div>
     </div>
   </div>
   <div class="settings-category-content">
-    <h1 class="settings-category-title">{{selectedCategory.name}}</h1>
+    <h1 class="settings-category-title">{{selectedCategory.name | translate}}</h1>
     <div class="settings-category-select">
 
       <ui-select
@@ -31,7 +31,7 @@
       >
         <ui-select-match>
           <div>
-            {{$select.selected.name}}
+            {{$select.selected.name | translate}}
           </div>
         </ui-select-match>
         <ui-select-choices repeat="category in categories | filter: { name: $select.search }" style="position:relative;">
@@ -44,10 +44,10 @@
             </div>
             <div>
               <div style="font-weight: 600;">
-                {{category.name}}
+                {{category.name | translate}}
               </div>
               <div style="opacity: 0.7;">
-                {{category.description}}
+                {{category.description | translate}}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- localize settings categories with translation keys
- translate category names and descriptions in settings menu
- add Japanese & English locale entries for all settings categories

## Testing
- `npm run lint` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_684219c7b4048322814c6919b96c2e13