### PR TITLE
Fix Japanese label for TTS category

### DIFF
--- a/src/gui/app/directives/settings/categories/advanced-settings.js
+++ b/src/gui/app/directives/settings/categories/advanced-settings.js
@@ -9,8 +9,8 @@
                 <div>
 
                     <firebot-setting
-                        name="Debug Mode"
-                        description="When Debug Mode is enabled, Firebot will log a lot more information to its log files. This is often useful when troubleshooting an obscure problem."
+                        name="{{'SETTINGS.ADVANCED.DEBUG_MODE.NAME' | translate }}"
+                        description="{{'SETTINGS.ADVANCED.DEBUG_MODE.DESCRIPTION' | translate }}"
                     >
                         <setting-description-addon>
                             <b>Firebot must be restarted for changes to this setting to take effect.</b>
@@ -22,8 +22,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="While Loop"
-                        description="Enable or disable the conditional 'While Loop' option in the Loop Effects effect."
+                        name="{{'SETTINGS.ADVANCED.WHILE_LOOP.NAME' | translate }}"
+                        description="{{'SETTINGS.ADVANCED.WHILE_LOOP.DESCRIPTION' | translate }}"
                     >
                         <setting-description-addon>
                             <b>If you aren't careful, you can cause an infinite loop and freeze Firebot.</b>
@@ -35,8 +35,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Quote ID Recalculation"
-                        description="Quote IDs in Firebot are static, even if a quote before another is deleted. If you would like to recalculate your quote IDs so that there isn't any skipped quote numbers, you can use this option."
+                        name="{{'SETTINGS.ADVANCED.QUOTE_ID_RECALCULATION.NAME' | translate }}"
+                        description="{{'SETTINGS.ADVANCED.QUOTE_ID_RECALCULATION.DESCRIPTION' | translate }}"
                     >
                         <setting-description-addon>
                             <b>We recommend that you make a backup first, just in case.</b>
@@ -48,8 +48,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Allow Quote .CSV Export"
-                        description="Whether or not you want the 'Export as .CSV' button available for quotes on the profile page."
+                        name="{{'SETTINGS.ADVANCED.ALLOW_QUOTE_CSV_EXPORT.NAME' | translate }}"
+                        description="{{'SETTINGS.ADVANCED.ALLOW_QUOTE_CSV_EXPORT.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ true: 'On', false: 'Off' }"
@@ -63,8 +63,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Persist Custom Variables"
-                        description="Whether or not custom variables should be persisted to a file when Firebot closes."
+                        name="{{'SETTINGS.ADVANCED.PERSIST_CUSTOM_VARIABLES.NAME' | translate }}"
+                        description="{{'SETTINGS.ADVANCED.PERSIST_CUSTOM_VARIABLES.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ true: 'On', false: 'Off' }"
@@ -77,8 +77,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Experimental Clip Player"
-                        description="When enabled, Firebot will use an experimental method to play Twitch clips in the overlay that bypasses content warnings. This is an experimental feature and isn't guaranteed to work. If Firebot is unable to play the clip, it will fall back to the default method."
+                        name="{{'SETTINGS.ADVANCED.EXPERIMENTAL_CLIP_PLAYER.NAME' | translate }}"
+                        description="{{'SETTINGS.ADVANCED.EXPERIMENTAL_CLIP_PLAYER.DESCRIPTION' | translate }}"
                     >
                         <toggle-button
                             toggle-model="settings.getSetting('UseExperimentalTwitchClipUrlResolver')"

--- a/src/gui/app/directives/settings/categories/backups-settings.js
+++ b/src/gui/app/directives/settings/categories/backups-settings.js
@@ -9,8 +9,8 @@
                     <div><strong>NOTE: These settings affect ALL user profiles.</strong></div>
 
                     <firebot-setting
-                        name="Max Backups"
-                        description="The maximum number of backups to keep. When Firebot makes a new backup, it will delete the oldest if this number has been reached."
+                        name="{{'SETTINGS.BACKUPS.MAX_BACKUPS.NAME' | translate }}"
+                        description="{{'SETTINGS.BACKUPS.MAX_BACKUPS.DESCRIPTION' | translate }}"
                     >
                         <dropdown-select
                             ng-init="currentMaxBackups = settings.getSetting('MaxBackupCount')"
@@ -23,8 +23,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Automatic Backup Options"
-                        description="Choose what Firebot should ignore in automatic backups."
+                        name="{{'SETTINGS.BACKUPS.AUTOMATIC_BACKUP_OPTIONS.NAME' | translate }}"
+                        description="{{'SETTINGS.BACKUPS.AUTOMATIC_BACKUP_OPTIONS.DESCRIPTION' | translate }}"
                     >
                         <div>
                         <label class="control-fb control--checkbox"
@@ -44,8 +44,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Automatic Backups"
-                        description="Choose when Firebot should make automatic backups."
+                        name="{{'SETTINGS.BACKUPS.AUTOMATIC_BACKUPS.NAME' | translate }}"
+                        description="{{'SETTINGS.BACKUPS.AUTOMATIC_BACKUPS.DESCRIPTION' | translate }}"
                     >
                         <div>
                         <label class="control-fb control--checkbox"
@@ -98,8 +98,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Manual Backup"
-                        description="Trigger a manual back up now."
+                        name="{{'SETTINGS.BACKUPS.MANUAL_BACKUP.NAME' | translate }}"
+                        description="{{'SETTINGS.BACKUPS.MANUAL_BACKUP.DESCRIPTION' | translate }}"
                     >
                         <div>
                             <span
@@ -120,8 +120,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Backup Management"
-                        description="View, restore, and delete previous backups."
+                        name="{{'SETTINGS.BACKUPS.BACKUP_MANAGEMENT.NAME' | translate }}"
+                        description="{{'SETTINGS.BACKUPS.BACKUP_MANAGEMENT.DESCRIPTION' | translate }}"
                     >
                         <div>
                             <firebot-button
@@ -132,8 +132,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Move Backup Folder"
-                        description="Choose where Firebot stores backups.">
+                        name="{{'SETTINGS.BACKUPS.MOVE_BACKUP_FOLDER.NAME' | translate }}"
+                        description="{{'SETTINGS.BACKUPS.MOVE_BACKUP_FOLDER.DESCRIPTION' | translate }}">
 
                         <setting-description-addon>
                             <div style="margin-top: 10px;"><strong>NOTE</strong>: Changing this setting will copy any existing backups from the current location to the new location. This will overwrite any files with the same name in the new location.</div>

--- a/src/gui/app/directives/settings/categories/database-settings.js
+++ b/src/gui/app/directives/settings/categories/database-settings.js
@@ -9,8 +9,8 @@
                 <div>
 
                     <firebot-setting
-                        name="Viewer Database"
-                        description="Turn on/off the viewer tracking database. This could improve performance in some cases."
+                        name="{{'SETTINGS.DATABASE.VIEWER_DATABASE.NAME' | translate }}"
+                        description="{{'SETTINGS.DATABASE.VIEWER_DATABASE.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ true: 'On', false: 'Off' }"
@@ -23,8 +23,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Auto Flag Bots"
-                        description="Prevents known bots from generating stats or showing up in active viewer lists."
+                        name="{{'SETTINGS.DATABASE.AUTO_FLAG_BOTS.NAME' | translate }}"
+                        description="{{'SETTINGS.DATABASE.AUTO_FLAG_BOTS.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ true: 'On', false: 'Off' }"
@@ -37,8 +37,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Viewers Table Page Size"
-                        description="Select how many viewers are displayed per page for the Viewers table."
+                        name="{{'SETTINGS.DATABASE.VIEWERS_TABLE_PAGE_SIZE.NAME' | translate }}"
+                        description="{{'SETTINGS.DATABASE.VIEWERS_TABLE_PAGE_SIZE.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="[5,10,15,20,25,30,35,40,45,50,55,60]"
@@ -51,8 +51,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Purge Viewer Data"
-                        description="Sometimes you may want to periodically purge viewer data to clear out inactive viewers."
+                        name="{{'SETTINGS.DATABASE.PURGE_VIEWER_DATA.NAME' | translate }}"
+                        description="{{'SETTINGS.DATABASE.PURGE_VIEWER_DATA.DESCRIPTION' | translate }}"
                     >
                         <firebot-button
                             text="View Purge Options"

--- a/src/gui/app/directives/settings/categories/effect-settings.js
+++ b/src/gui/app/directives/settings/categories/effect-settings.js
@@ -8,8 +8,8 @@
             template: `
                 <div>
                     <firebot-setting
-                        name="Default Effect Labels"
-                        description="When enabled, Firebot will automatically generate labels for (most) effects that don't have a custom label set."
+                        name="{{'SETTINGS.EFFECTS.DEFAULT_EFFECT_LABELS.NAME' | translate }}"
+                        description="{{'SETTINGS.EFFECTS.DEFAULT_EFFECT_LABELS.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ true: 'On', false: 'Off' }"

--- a/src/gui/app/directives/settings/categories/integration-settings.js
+++ b/src/gui/app/directives/settings/categories/integration-settings.js
@@ -22,19 +22,18 @@
                   class="btn btn-default"
                   ng-show="integration.configurable"
                   ng-click="integrations.openIntegrationSettings(integration.id)"
-                  aria-label="Configure {{integration.name}}"
+                  aria-label="{{'SETTINGS.INTEGRATIONS.CONFIGURE_BUTTON' | translate }} {{integration.name}}"
                 >
-                  Configure
+                  {{'SETTINGS.INTEGRATIONS.CONFIGURE_BUTTON' | translate }}
                 </button>
                 <button
                   class="btn btn-default"
                   ng-show="integration.linkType === 'auth' || integration.linkType === 'id' || integration.linkType === 'other'"
                   ng-click="integrations.toggleLinkforIntegration(integration.id)"
-                  aria-label="{{integrations.integrationIsLinked(integration.id) ? 'Unlink'
-                  : 'Link'}} {{integration.name}}"
+                  aria-label="{{integrations.integrationIsLinked(integration.id) ? ('SETTINGS.INTEGRATIONS.UNLINK_BUTTON' | translate) : ('SETTINGS.INTEGRATIONS.LINK_BUTTON' | translate)}} {{integration.name}}"
                 >
-                  {{integrations.integrationIsLinked(integration.id) ? 'Unlink'
-                  : 'Link'}}
+                  {{integrations.integrationIsLinked(integration.id) ? ('SETTINGS.INTEGRATIONS.UNLINK_BUTTON' | translate)
+                  : ('SETTINGS.INTEGRATIONS.LINK_BUTTON' | translate)}}
                 </button>
               </div>
             </div>

--- a/src/gui/app/directives/settings/categories/overlay-settings.js
+++ b/src/gui/app/directives/settings/categories/overlay-settings.js
@@ -9,8 +9,8 @@
                 <div>
 
                     <firebot-setting
-                        name="Overlay URL"
-                        description="Open the Overlay Setup modal to get access to the url and how to set it up."
+                        name="{{'SETTINGS.OVERLAY.OVERLAY_URL.NAME' | translate }}"
+                        description="{{'SETTINGS.OVERLAY.OVERLAY_URL.DESCRIPTION' | translate }}"
                     >
                         <firebot-button
                             text="Get Overlay Path"
@@ -19,8 +19,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Overlay Instances"
-                        description="Enable or disable the ability to use multiple overlay instances in your broadcasting software. When on, you will be able to pick which instance you want a video or image effect to show in. This is useful if you use greenscreen footage that you need to chroma key but don't want to affect your other videos and images."
+                        name="{{'SETTINGS.OVERLAY.OVERLAY_INSTANCES.NAME' | translate }}"
+                        description="{{'SETTINGS.OVERLAY.OVERLAY_INSTANCES.DESCRIPTION' | translate }}"
                     >
                         <span
                             style="padding-right: 10px"
@@ -39,10 +39,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Force Effects to Continue on Overlay Refresh"
-                        description="When refreshing an overlay or using the Clear Effects effect on it, this will force
-                        any Play Video or Play Sound effects currently playing on that overlay to continue to the next effect,
-                        even if they're set to wait."
+                        name="{{'SETTINGS.OVERLAY.FORCE_EFFECTS_TO_CONTINUE.NAME' | translate }}"
+                        description="{{'SETTINGS.OVERLAY.FORCE_EFFECTS_TO_CONTINUE.DESCRIPTION' | translate }}"
                     >
                         <toggle-button
                             toggle-model="settings.getSetting('ForceOverlayEffectsToContinueOnRefresh')"
@@ -55,8 +53,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Font Management"
-                        description="Manage fonts for use with the Show Text effect in the overlay. Any changes to fonts will require a restart to Firebot and then refreshing the overlay."
+                        name="{{'SETTINGS.OVERLAY.FONT_MANAGEMENT.NAME' | translate }}"
+                        description="{{'SETTINGS.OVERLAY.FONT_MANAGEMENT.DESCRIPTION' | translate }}"
                     >
                         <firebot-button
                             text="Manage Fonts"

--- a/src/gui/app/directives/settings/categories/scripts-settings.js
+++ b/src/gui/app/directives/settings/categories/scripts-settings.js
@@ -9,8 +9,8 @@
                 <div>
 
                     <firebot-setting
-                        name="Custom Scripts"
-                        description="Firebot supports custom scripts! You must opt-in to use this feature as it is potentially dangerous. Please only run scripts from sources you trust."
+                        name="{{'SETTINGS.SCRIPTS.CUSTOM_SCRIPTS.NAME' | translate }}"
+                        description="{{'SETTINGS.SCRIPTS.CUSTOM_SCRIPTS.DESCRIPTION' | translate }}"
                     >
                         <setting-description-addon>
                             <div style="margin-top: 10px;">Want to write your own scripts? Learn how <a
@@ -30,8 +30,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Startup Scripts"
-                        description="Startup Scripts are custom scripts that run when Firebot starts. Scripts which add new effects, variables, event types, etc should be loaded here."
+                        name="{{'SETTINGS.SCRIPTS.STARTUP_SCRIPTS.NAME' | translate }}"
+                        description="{{'SETTINGS.SCRIPTS.STARTUP_SCRIPTS.DESCRIPTION' | translate }}"
                     >
                         <firebot-button
                             text="Manage Startup Scripts"
@@ -41,8 +41,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Clear Custom Script Cache"
-                        description="Whether or not you want custom scripts to be cleared from memory before they are executed. Enabling this helps when actively developing a custom script, otherwise Firebot wont reflect changes to your script until restarted. Everyday users should leave this disabled."
+                        name="{{'SETTINGS.SCRIPTS.CLEAR_CUSTOM_SCRIPT_CACHE.NAME' | translate }}"
+                        description="{{'SETTINGS.SCRIPTS.CLEAR_CUSTOM_SCRIPT_CACHE.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ true: 'On', false: 'Off' }"

--- a/src/gui/app/directives/settings/categories/setups-settings.js
+++ b/src/gui/app/directives/settings/categories/setups-settings.js
@@ -8,32 +8,32 @@
             template: `
                 <div>
 
-                    <firebot-setting 
-                        name="Import Setup"
-                        description="Import a Firebot Setup (.firebotsetup file) made by someone else!"
+                    <firebot-setting
+                        name="{{'SETTINGS.SETUPS.IMPORT_SETUP.NAME' | translate }}"
+                        description="{{'SETTINGS.SETUPS.IMPORT_SETUP.DESCRIPTION' | translate }}"
                     >
-                        <firebot-button 
-                            text="Import Setup"
+                        <firebot-button
+                            text="{{'SETTINGS.SETUPS.IMPORT_SETUP.BUTTON' | translate }}"
                             ng-click="showImportSetupModal()"
                         />
                     </firebot-setting>
 
-                    <firebot-setting 
-                        name="Create Setup"
-                        description="Create a new Firebot Setup (a collection of commands, events, currencies, etc) and share it with others!"
+                    <firebot-setting
+                        name="{{'SETTINGS.SETUPS.CREATE_SETUP.NAME' | translate }}"
+                        description="{{'SETTINGS.SETUPS.CREATE_SETUP.DESCRIPTION' | translate }}"
                     >
-                        <firebot-button 
-                            text="Create New Setup"
+                        <firebot-button
+                            text="{{'SETTINGS.SETUPS.CREATE_SETUP.BUTTON' | translate }}"
                             ng-click="showCreateSetupModal()"
                         />
                     </firebot-setting>
 
-                    <firebot-setting 
-                        name="Remove Setup"
-                        description="Select a Setup file to have Firebot find and remove all matching components (commands, events, etc) currently saved for you. Useful if you want to completely remove a previously imported Setup."
+                    <firebot-setting
+                        name="{{'SETTINGS.SETUPS.REMOVE_SETUP.NAME' | translate }}"
+                        description="{{'SETTINGS.SETUPS.REMOVE_SETUP.DESCRIPTION' | translate }}"
                     >
-                        <firebot-button 
-                            text="Remove Setup"
+                        <firebot-button
+                            text="{{'SETTINGS.SETUPS.REMOVE_SETUP.BUTTON' | translate }}"
                             ng-click="showRemoveSetupModal()"
                         />
                     </firebot-setting>

--- a/src/gui/app/directives/settings/categories/trigger-settings.js
+++ b/src/gui/app/directives/settings/categories/trigger-settings.js
@@ -8,11 +8,11 @@
             template: `
                 <div>
                     <firebot-setting-category
-                        name="Commands"
+                        name="{{'SETTINGS.TRIGGERS.COMMANDS_CATEGORY' | translate}}"
                     />
                     <firebot-setting
-                        name="Default Mode For New Commands"
-                        description="The default command mode to use when creating new commands (Simple vs Advanced)"
+                        name="{{'SETTINGS.TRIGGERS.DEFAULT_MODE_FOR_NEW_COMMANDS.NAME' | translate }}"
+                        description="{{'SETTINGS.TRIGGERS.DEFAULT_MODE_FOR_NEW_COMMANDS.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ true: 'Advanced', false: 'Simple' }"
@@ -20,13 +20,13 @@
                             selected="selectedCmdMode"
                             on-update="settings.saveSetting('DefaultToAdvancedCommandMode', option === 'true')"
                             right-justify="true"
-                            aria-label="Choose your Default Mode For New Commands"
+                            aria-label="{{'SETTINGS.TRIGGERS.DEFAULT_MODE_FOR_NEW_COMMANDS.NAME' | translate }}"
                         />
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Allow Shared Chat To Trigger Commands"
-                        description="Allow commands to be triggered by chat messages sent in other channels during Twitch Shared Chat"
+                        name="{{'SETTINGS.TRIGGERS.ALLOW_SHARED_CHAT_TO_TRIGGER_COMMANDS.NAME' | translate }}"
+                        description="{{'SETTINGS.TRIGGERS.ALLOW_SHARED_CHAT_TO_TRIGGER_COMMANDS.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ true: 'Yes', false: 'No' }"
@@ -34,17 +34,17 @@
                             selected="allowSharedChatCommands"
                             on-update="settings.saveSetting('AllowCommandsInSharedChat', option === 'true')"
                             right-justify="true"
-                            aria-label="Allow Shared Chat To Trigger Commands"
+                            aria-label="{{'SETTINGS.TRIGGERS.ALLOW_SHARED_CHAT_TO_TRIGGER_COMMANDS.NAME' | translate }}"
                         />
                     </firebot-setting>
 
                     <firebot-setting-category
-                        name="Events"
+                        name="{{'SETTINGS.TRIGGERS.EVENTS_CATEGORY' | translate}}"
                         pad-top="true"
                     />
                     <firebot-setting
-                        name="Ignore Related Gift Sub Events"
-                        description="When this is enabled, Firebot will attempt to ignore subsequent Gift Sub events after a Community Gift Sub event. This means only the Community Sub event would fire instead of the Community Sub event AND an additional Gift Sub event for every recipient."
+                        name="{{'SETTINGS.TRIGGERS.IGNORE_RELATED_GIFT_SUB_EVENTS.NAME' | translate }}"
+                        description="{{'SETTINGS.TRIGGERS.IGNORE_RELATED_GIFT_SUB_EVENTS.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ true: 'Yes', false: 'No' }"
@@ -52,13 +52,13 @@
                             selected="ignoreSubEvents"
                             on-update="settings.saveSetting('IgnoreSubsequentSubEventsAfterCommunitySub', option === 'true')"
                             right-justify="true"
-                            aria-label="enable or disable Ignore Related Gift Sub Events"
+                            aria-label="{{'SETTINGS.TRIGGERS.IGNORE_RELATED_GIFT_SUB_EVENTS.NAME' | translate }}"
                         />
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Upcoming Scheduled Ad Break Trigger"
-                        description="Use this to set the number of minutes before the next scheduled ad break to trigger the Scheduled Ad Break Starting Soon event, or disable it completely. This may trigger sooner than the configured value at the beginning of a stream, depending on your Twitch Ads Manager settings. NOTE: You must be a Twitch affiliate/partner and have the Twitch Ads Manager enabled in order for this event to trigger."
+                        name="{{'SETTINGS.TRIGGERS.UPCOMING_SCHEDULED_AD_BREAK_TRIGGER.NAME' | translate }}"
+                        description="{{'SETTINGS.TRIGGERS.UPCOMING_SCHEDULED_AD_BREAK_TRIGGER.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="{ 0: 'Disabled', 1: '1 minute', 3: '3 minutes', 5: '5 minutes', 10: '10 minutes', 15: '15 minutes', 20: '20 minutes' }"
@@ -66,7 +66,7 @@
                             selected="triggerUpcomingAdBreakMinutes"
                             on-update="settings.saveSetting('TriggerUpcomingAdBreakMinutes', option)"
                             right-justify="true"
-                            aria-label="Choose your Upcoming Scheduled Ad Break Trigger"
+                            aria-label="{{'SETTINGS.TRIGGERS.UPCOMING_SCHEDULED_AD_BREAK_TRIGGER.NAME' | translate }}"
                         />
                     </firebot-setting>
                 </div>

--- a/src/gui/app/directives/settings/categories/tts-settings.js
+++ b/src/gui/app/directives/settings/categories/tts-settings.js
@@ -9,8 +9,8 @@
                 <div>
 
                     <firebot-setting
-                        name="TTS Voice"
-                        description="The voice that is used for the TTS."
+                        name="{{'SETTINGS.TTS.TTS_VOICE.NAME' | translate }}"
+                        description="{{'SETTINGS.TTS.TTS_VOICE.DESCRIPTION' | translate }}"
                     >
                         <firebot-select
                             options="ttsVoiceOptions"
@@ -23,8 +23,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="TTS Volume"
-                        description="The volume at which the TTS speaks."
+                        name="{{'SETTINGS.TTS.TTS_VOLUME.NAME' | translate }}"
+                        description="{{'SETTINGS.TTS.TTS_VOLUME.DESCRIPTION' | translate }}"
                     >
                         <div class="volume-slider-wrapper"  style="width: 75%">
                             <i class="fal fa-volume-down volume-low" style="font-size: 25px"></i>
@@ -37,8 +37,8 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="TTS Speak Rate"
-                        description="The rate at which the TTS speaks: 1 is normal. 0.5 is half as fast. 2 is 2x as fast, etc."
+                        name="{{'SETTINGS.TTS.TTS_SPEAK_RATE.NAME' | translate }}"
+                        description="{{'SETTINGS.TTS.TTS_SPEAK_RATE.DESCRIPTION' | translate }}"
                     >
                         <div class="volume-slider-wrapper" style="width: 75%">
                             <i class="fal fa-turtle volume-low" style="font-size: 25px"></i>
@@ -52,11 +52,11 @@
                     </firebot-setting>
 
                     <firebot-setting
-                        name="Test TTS"
-                        description="Test the current TTS settings."
+                        name="{{'SETTINGS.TTS.TEST_TTS.NAME' | translate }}"
+                        description="{{'SETTINGS.TTS.TEST_TTS.DESCRIPTION' | translate }}"
                     >
                         <firebot-button
-                            text="Speak Test Message"
+                            text="{{'SETTINGS.TTS.SPEAK_TEST_MESSAGE' | translate }}"
                             ng-click="testTTS()"
                         />
                     </firebot-setting>

--- a/src/gui/app/lang/locale-en.json
+++ b/src/gui/app/lang/locale-en.json
@@ -130,6 +130,158 @@
         "NAME": "Open Stream Preview on Launch",
         "DESCRIPTION": "Automatically open the Stream Preview window when Firebot launches."
       }
+    },
+    "TRIGGERS": {
+      "COMMANDS_CATEGORY": "Commands",
+      "DEFAULT_MODE_FOR_NEW_COMMANDS": {
+        "NAME": "Default Mode For New Commands",
+        "DESCRIPTION": "The default command mode to use when creating new commands (Simple vs Advanced)"
+      },
+      "ALLOW_SHARED_CHAT_TO_TRIGGER_COMMANDS": {
+        "NAME": "Allow Shared Chat To Trigger Commands",
+        "DESCRIPTION": "Allow commands to be triggered by chat messages sent in other channels during Twitch Shared Chat"
+      },
+      "EVENTS_CATEGORY": "Events",
+      "IGNORE_RELATED_GIFT_SUB_EVENTS": {
+        "NAME": "Ignore Related Gift Sub Events",
+        "DESCRIPTION": "When this is enabled, Firebot will attempt to ignore subsequent Gift Sub events after a Community Gift Sub event. This means only the Community Sub event would fire instead of the Community Sub event AND an additional Gift Sub event for every recipient."
+      },
+      "UPCOMING_SCHEDULED_AD_BREAK_TRIGGER": {
+        "NAME": "Upcoming Scheduled Ad Break Trigger",
+        "DESCRIPTION": "Use this to set the number of minutes before the next scheduled ad break to trigger the Scheduled Ad Break Starting Soon event, or disable it completely. This may trigger sooner than the configured value at the beginning of a stream, depending on your Twitch Ads Manager settings. NOTE: You must be a Twitch affiliate/partner and have the Twitch Ads Manager enabled in order for this event to trigger."
+      }
+    },
+    "EFFECTS": {
+      "DEFAULT_EFFECT_LABELS": {
+        "NAME": "Default Effect Labels",
+        "DESCRIPTION": "When enabled, Firebot will automatically generate labels for (most) effects that don't have a custom label set."
+      }
+    },
+    "DATABASE": {
+      "VIEWER_DATABASE": {
+        "NAME": "Viewer Database",
+        "DESCRIPTION": "Turn on/off the viewer tracking database. This could improve performance in some cases."
+      },
+      "AUTO_FLAG_BOTS": {
+        "NAME": "Auto Flag Bots",
+        "DESCRIPTION": "Prevents known bots from generating stats or showing up in active viewer lists."
+      },
+      "VIEWERS_TABLE_PAGE_SIZE": {
+        "NAME": "Viewers Table Page Size",
+        "DESCRIPTION": "Select how many viewers are displayed per page for the Viewers table."
+      },
+      "PURGE_VIEWER_DATA": {
+        "NAME": "Purge Viewer Data",
+        "DESCRIPTION": "Sometimes you may want to periodically purge viewer data to clear out inactive viewers."
+      }
+    },
+    "OVERLAY": {
+      "OVERLAY_URL": {
+        "NAME": "Overlay URL",
+        "DESCRIPTION": "Open the Overlay Setup modal to get access to the url and how to set it up."
+      },
+      "OVERLAY_INSTANCES": {
+        "NAME": "Overlay Instances",
+        "DESCRIPTION": "Enable or disable the ability to use multiple overlay instances in your broadcasting software. When on, you can choose which instance to show a video or image effect in."
+      },
+      "FORCE_EFFECTS_TO_CONTINUE": {
+        "NAME": "Force Effects to Continue on Overlay Refresh",
+        "DESCRIPTION": "When refreshing an overlay or using the Clear Effects effect on it, this will force any Play Video or Play Sound effects currently playing on that overlay to continue to the next effect, even if they're set to wait."
+      },
+      "FONT_MANAGEMENT": {
+        "NAME": "Font Management",
+        "DESCRIPTION": "Manage fonts for use with the Show Text effect in the overlay. Any changes to fonts will require restarting Firebot and then refreshing the overlay."
+      }
+    },
+    "INTEGRATIONS": {
+      "CONFIGURE_BUTTON": "Configure",
+      "LINK_BUTTON": "Link",
+      "UNLINK_BUTTON": "Unlink"
+    },
+    "TTS": {
+      "TTS_VOICE": {
+        "NAME": "TTS Voice",
+        "DESCRIPTION": "The voice that is used for the TTS."
+      },
+      "TTS_VOLUME": {
+        "NAME": "TTS Volume",
+        "DESCRIPTION": "The volume at which the TTS speaks."
+      },
+      "TTS_SPEAK_RATE": {
+        "NAME": "TTS Speak Rate",
+        "DESCRIPTION": "The rate at which the TTS speaks: 1 is normal. 0.5 is half as fast. 2 is 2x as fast, etc."
+      },
+      "TEST_TTS": {
+        "NAME": "Test TTS",
+        "DESCRIPTION": "Test the current TTS settings."
+      },
+      "SPEAK_TEST_MESSAGE": "Speak Test Message"
+    },
+    "BACKUPS": {
+      "MAX_BACKUPS": {
+        "NAME": "Max Backups",
+        "DESCRIPTION": "The maximum number of backups to keep. When Firebot makes a new backup, it will delete the oldest if this number has been reached."
+      },
+      "AUTOMATIC_BACKUP_OPTIONS": {
+        "NAME": "Automatic Backup Options",
+        "DESCRIPTION": "Choose what Firebot should ignore in automatic backups."
+      },
+      "AUTOMATIC_BACKUPS": {
+        "NAME": "Automatic Backups",
+        "DESCRIPTION": "Choose when Firebot should make automatic backups."
+      },
+      "MANUAL_BACKUP": {
+        "NAME": "Manual Backup",
+        "DESCRIPTION": "Trigger a manual back up now."
+      },
+      "BACKUP_MANAGEMENT": {
+        "NAME": "Backup Management",
+        "DESCRIPTION": "View, restore, and delete previous backups."
+      },
+      "MOVE_BACKUP_FOLDER": {
+        "NAME": "Move Backup Folder",
+        "DESCRIPTION": "Choose where Firebot stores backups."
+      }
+    },
+    "SCRIPTS": {
+      "CUSTOM_SCRIPTS": {
+        "NAME": "Custom Scripts",
+        "DESCRIPTION": "Firebot supports custom scripts! You must opt-in to use this feature as it is potentially dangerous. Please only run scripts from sources you trust."
+      },
+      "STARTUP_SCRIPTS": {
+        "NAME": "Startup Scripts",
+        "DESCRIPTION": "Startup Scripts are custom scripts that run when Firebot starts. Scripts which add new effects, variables, event types, etc should be loaded here."
+      },
+      "CLEAR_CUSTOM_SCRIPT_CACHE": {
+        "NAME": "Clear Custom Script Cache",
+        "DESCRIPTION": "Whether or not you want custom scripts to be cleared from memory before they are executed. Enabling this helps when actively developing a custom script, otherwise Firebot wont reflect changes to your script until restarted. Everyday users should leave this disabled."
+      }
+    },
+    "ADVANCED": {
+      "DEBUG_MODE": {
+        "NAME": "Debug Mode",
+        "DESCRIPTION": "When Debug Mode is enabled, Firebot will log a lot more information to its log files. This is often useful when troubleshooting an obscure problem."
+      },
+      "WHILE_LOOP": {
+        "NAME": "While Loop",
+        "DESCRIPTION": "Enable or disable the conditional 'While Loop' option in the Loop Effects effect."
+      },
+      "QUOTE_ID_RECALCULATION": {
+        "NAME": "Quote ID Recalculation",
+        "DESCRIPTION": "Quote IDs in Firebot are static, even if a quote before another is deleted. If you would like to recalculate your quote IDs so that there isn't any skipped quote numbers, you can use this option."
+      },
+      "ALLOW_QUOTE_CSV_EXPORT": {
+        "NAME": "Allow Quote .CSV Export",
+        "DESCRIPTION": "Whether or not you want the 'Export as .CSV' button available for quotes on the profile page."
+      },
+      "PERSIST_CUSTOM_VARIABLES": {
+        "NAME": "Persist Custom Variables",
+        "DESCRIPTION": "Whether or not custom variables should be persisted to a file when Firebot closes."
+      },
+      "EXPERIMENTAL_CLIP_PLAYER": {
+        "NAME": "Experimental Clip Player",
+        "DESCRIPTION": "When enabled, Firebot will use an experimental method to play Twitch clips in the overlay that bypasses content warnings. This is an experimental feature and isn't guaranteed to work. If Firebot is unable to play the clip, it will fall back to the default method."
+      }
     }
   },
   "CURRENCY_PAGE": {

--- a/src/gui/app/lang/locale-ja.json
+++ b/src/gui/app/lang/locale-ja.json
@@ -130,6 +130,158 @@
         "NAME": "起動時にストリームプレビューを開く",
         "DESCRIPTION": "Firebot起動時に自動的にストリームプレビューウィンドウを開きます。"
       }
+    },
+    "TRIGGERS": {
+      "COMMANDS_CATEGORY": "コマンド",
+      "DEFAULT_MODE_FOR_NEW_COMMANDS": {
+        "NAME": "新規コマンドのデフォルトモード",
+        "DESCRIPTION": "新しいコマンドを作成する際に使用する既定のモード（シンプル / 上級）"
+      },
+      "ALLOW_SHARED_CHAT_TO_TRIGGER_COMMANDS": {
+        "NAME": "共有チャットからのコマンド実行を許可",
+        "DESCRIPTION": "Twitchの共有チャットで他チャンネルに送信されたメッセージでもコマンドが起動するようにします"
+      },
+      "EVENTS_CATEGORY": "イベント",
+      "IGNORE_RELATED_GIFT_SUB_EVENTS": {
+        "NAME": "関連ギフトサブイベントを無視",
+        "DESCRIPTION": "有効にすると、コミュニティギフトサブの後に発生する個別ギフトサブイベントを無視します。これにより、コミュニティサブイベントのみが発生します。"
+      },
+      "UPCOMING_SCHEDULED_AD_BREAK_TRIGGER": {
+        "NAME": "次の予定広告開始通知",
+        "DESCRIPTION": "次の予定広告開始まで何分前に\"広告開始間近\"イベントを発火させるか設定します。無効にもできます。配信開始直後は設定値より早く発火する場合があります。※ TwitchのAds Managerを有効にしたアフィリエイトまたはパートナーである必要があります。"
+      }
+    },
+    "EFFECTS": {
+      "DEFAULT_EFFECT_LABELS": {
+        "NAME": "既定のエフェクトラベル",
+        "DESCRIPTION": "有効にすると、カスタムラベルがないエフェクトに自動でラベルを生成します。"
+      }
+    },
+    "DATABASE": {
+      "VIEWER_DATABASE": {
+        "NAME": "視聴者データベース",
+        "DESCRIPTION": "視聴者のトラッキングデータベースをオン/オフします。パフォーマンス向上につながる場合があります。"
+      },
+      "AUTO_FLAG_BOTS": {
+        "NAME": "Botの自動判定",
+        "DESCRIPTION": "既知のBotが統計を生成したりアクティブ視聴者一覧に表示されないようにします。"
+      },
+      "VIEWERS_TABLE_PAGE_SIZE": {
+        "NAME": "視聴者表のページサイズ",
+        "DESCRIPTION": "Viewersテーブルで1ページに表示する視聴者数を選択します。"
+      },
+      "PURGE_VIEWER_DATA": {
+        "NAME": "視聴者データの削除",
+        "DESCRIPTION": "不要な視聴者データを定期的に削除したい場合に使用します。"
+      }
+    },
+    "OVERLAY": {
+      "OVERLAY_URL": {
+        "NAME": "オーバーレイ URL",
+        "DESCRIPTION": "オーバーレイ設定モーダルを開き、URL取得や設定方法を確認します。"
+      },
+      "OVERLAY_INSTANCES": {
+        "NAME": "オーバーレイインスタンス",
+        "DESCRIPTION": "配信ソフトで複数のオーバーレイインスタンスを使用できるようにします。オンにすると、どのインスタンスで動画や画像エフェクトを表示するか選択できます。"
+      },
+      "FORCE_EFFECTS_TO_CONTINUE": {
+        "NAME": "オーバーレイ更新時にエフェクトを継続",
+        "DESCRIPTION": "オーバーレイを更新する際やClear Effectsを使用する際に、待機設定されていても再生中の動画/音声エフェクトを次のエフェクトへ進めます。"
+      },
+      "FONT_MANAGEMENT": {
+        "NAME": "フォント管理",
+        "DESCRIPTION": "オーバーレイのShow Textエフェクトで使用するフォントを管理します。変更を反映するにはFirebot再起動後にオーバーレイを更新してください。"
+      }
+    },
+    "INTEGRATIONS": {
+      "CONFIGURE_BUTTON": "設定",
+      "LINK_BUTTON": "リンク",
+      "UNLINK_BUTTON": "解除"
+    },
+    "TTS": {
+      "TTS_VOICE": {
+        "NAME": "TTS音声",
+        "DESCRIPTION": "TTSで使用する音声です。"
+      },
+      "TTS_VOLUME": {
+        "NAME": "TTS音量",
+        "DESCRIPTION": "TTSが話す音量です。"
+      },
+      "TTS_SPEAK_RATE": {
+        "NAME": "TTS速度",
+        "DESCRIPTION": "TTSが話す速さです。1が通常、0.5で半分、2で2倍速。"
+      },
+      "TEST_TTS": {
+        "NAME": "TTSテスト",
+        "DESCRIPTION": "現在のTTS設定をテストします。"
+      },
+      "SPEAK_TEST_MESSAGE": "テストメッセージを再生"
+    },
+    "BACKUPS": {
+      "MAX_BACKUPS": {
+        "NAME": "バックアップの最大数",
+        "DESCRIPTION": "保持するバックアップの最大数です。新しいバックアップ作成時、この数に達していれば最も古いものを削除します。"
+      },
+      "AUTOMATIC_BACKUP_OPTIONS": {
+        "NAME": "自動バックアップの対象",
+        "DESCRIPTION": "自動バックアップで除外する項目を選択します。"
+      },
+      "AUTOMATIC_BACKUPS": {
+        "NAME": "自動バックアップ",
+        "DESCRIPTION": "Firebotが自動バックアップを行うタイミングを設定します。"
+      },
+      "MANUAL_BACKUP": {
+        "NAME": "手動バックアップ",
+        "DESCRIPTION": "今すぐ手動バックアップを実行します。"
+      },
+      "BACKUP_MANAGEMENT": {
+        "NAME": "バックアップ管理",
+        "DESCRIPTION": "過去のバックアップの閲覧、復元、削除を行います。"
+      },
+      "MOVE_BACKUP_FOLDER": {
+        "NAME": "バックアップフォルダーの移動",
+        "DESCRIPTION": "バックアップを保存する場所を変更します。"
+      }
+    },
+    "SCRIPTS": {
+      "CUSTOM_SCRIPTS": {
+        "NAME": "カスタムスクリプト",
+        "DESCRIPTION": "Firebotはカスタムスクリプトに対応しています。危険を伴う可能性があるため、使用するにはオプトインが必要です。信頼できるソースのスクリプトのみ実行してください。"
+      },
+      "STARTUP_SCRIPTS": {
+        "NAME": "起動スクリプト",
+        "DESCRIPTION": "Firebot起動時に実行されるカスタムスクリプトです。新しいエフェクトや変数、イベントタイプなどを追加するスクリプトをここで読み込みます。"
+      },
+      "CLEAR_CUSTOM_SCRIPT_CACHE": {
+        "NAME": "カスタムスクリプトキャッシュのクリア",
+        "DESCRIPTION": "スクリプト実行前にメモリからスクリプトをクリアするかどうかを設定します。スクリプト開発中に変更を即座に反映させたい場合に有効にします。通常は無効のままで構いません。"
+      }
+    },
+    "ADVANCED": {
+      "DEBUG_MODE": {
+        "NAME": "デバッグモード",
+        "DESCRIPTION": "デバッグモードを有効にするとログファイルへより詳細な情報が出力されます。問題解決時に役立ちます。"
+      },
+      "WHILE_LOOP": {
+        "NAME": "While ループ",
+        "DESCRIPTION": "Loop Effectsエフェクトで条件付き'While Loop'オプションを使用するかどうかを切り替えます。"
+      },
+      "QUOTE_ID_RECALCULATION": {
+        "NAME": "引用IDの再計算",
+        "DESCRIPTION": "引用IDは削除しても変動しません。IDの欠番をなくしたい場合に再計算します。"
+      },
+      "ALLOW_QUOTE_CSV_EXPORT": {
+        "NAME": ".CSV形式での引用エクスポートを許可",
+        "DESCRIPTION": "プロフィールページの引用に\".CSVでエクスポート\"ボタンを表示するかどうか。"
+      },
+      "PERSIST_CUSTOM_VARIABLES": {
+        "NAME": "カスタム変数の保存",
+        "DESCRIPTION": "Firebot終了時にカスタム変数をファイルへ保存するかどうか。"
+      },
+      "EXPERIMENTAL_CLIP_PLAYER": {
+        "NAME": "実験的なクリッププレーヤー",
+        "DESCRIPTION": "Twitchクリップをコンテンツ警告なしで再生する実験的な方法を使用します。うまく再生できない場合は従来の方法にフォールバックします。"
+      }
     }
   },
   "CURRENCY_PAGE": {
@@ -159,7 +311,7 @@
       },
       "TRIGGERS": {
         "NAME": "トリガー",
-        "DESCRIPTION": "コマンドやイベントなど、各種トリガーの動作を調整します。"
+        "DESCRIPTION": "コマンドやイベントなど、トリガーの動作を調整します。"
       },
       "EFFECTS": {
         "NAME": "エフェクト",
@@ -178,7 +330,7 @@
         "DESCRIPTION": "Firebotを外部ツールやアプリと連携させます。"
       },
       "TTS": {
-        "NAME": "TTS",
+        "NAME": "読み上げ",
         "DESCRIPTION": "既定のTTS音声に関する設定。"
       },
       "BACKUPS": {
@@ -191,7 +343,7 @@
       },
       "ADVANCED": {
         "NAME": "高度な設定",
-        "DESCRIPTION": "デバッグモードやwhileループなど、上級者向け設定。"
+        "DESCRIPTION": "デバッグモードや while ループなど、上級者向けの設定です。"
       }
     }
   }


### PR DESCRIPTION
## Summary
- update Japanese locale so the TTS settings category uses a proper Japanese label
- refine wording for trigger and advanced settings descriptions
- localize names and descriptions for trigger settings, allowing sidebar details to display in Japanese
- localize all remaining settings categories so every option can be translated

## Testing
- `npm run lint` *(fails: grunt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421d695b4c8322b48e49462a443e52